### PR TITLE
[41기 이다혜] Add: 판매하기 기능추가

### DIFF
--- a/src/components/CardList/Card.jsx
+++ b/src/components/CardList/Card.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import SelectOpt from './SelectOpt';
 
-const Card = ({ product, selectOpt }) => {
+const Card = ({ product, setOptValue, selectOpt }) => {
   const { title, thumbnail_img, price, status } = product;
   const isProductSoldout = status === 'soldout';
   const isProductSelling = status === 'selling';
@@ -24,7 +24,13 @@ const Card = ({ product, selectOpt }) => {
       </ImgWrapper>
       <Name>{title}</Name>
       <Price>{parseInt(price).toLocaleString()}원</Price>
-      {selectOpt && <SelectOpt status={status} />}
+      {selectOpt && (
+        <SelectOpt
+          productId={product.id}
+          status={status}
+          setOptValue={setOptValue}
+        />
+      )}
     </CardWrapper>
   );
 };
@@ -39,6 +45,8 @@ const ImgWrapper = styled.div`
   position: relative;
   overflow: hidden;
   border-radius: 5px;
+  width: 210px;
+  height: 210px;
 `;
 
 const ProductImg = styled.img`

--- a/src/components/CardList/List.jsx
+++ b/src/components/CardList/List.jsx
@@ -4,27 +4,68 @@ import ProductCard from './Card';
 
 const List = ({ url, column, selectOpt }) => {
   const [products, setProducts] = useState([]);
+  const isMypage = url.includes('/mypage');
 
   useEffect(() => {
-    fetch(url)
+    fetch(url, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json;charset=utf-8',
+        Authorization:
+          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOnsiaWQiOjN9LCJpYXQiOjE2NzU5MDkzNzB9.I7aqL2ZAFGO9iBwmzOlDly0ZRCNd7rERJIfkS1Zt4pQ',
+      },
+    })
       .then(res => res.json())
       .then(data => {
-        console.log(data);
-        setProducts(data);
+        isMypage ? setProducts(data.products) : setProducts(data);
       });
   }, []);
 
+  const setOptValue = (selectedStatus, productId) => {
+    console.log('상태변경실행!', selectedStatus, productId);
+
+    fetch('productStatus Change Url', {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json;charset=utf-8',
+        Authorization: localStorage.getItem('accessToken'),
+      },
+      body: JSON.stringify({
+        productId: 0,
+        status: selectedStatus,
+      }),
+    })
+      .then(res => res.json())
+      .then(data => {
+        console.log(data);
+      });
+
+    const newProducts = products.map(item => {
+      if (item.id === productId) {
+        return {
+          ...item,
+          status: selectedStatus,
+        };
+      }
+
+      return item;
+    });
+    setProducts(newProducts);
+  };
+
   return (
     <ListWrapper column={column}>
-      {products.map(product => {
-        return (
-          <ProductCard
-            key={product.id}
-            product={product}
-            selectOpt={selectOpt}
-          />
-        );
-      })}
+      {products.length > 0 &&
+        products.map(product => {
+          return (
+            <ProductCard
+              key={product.id}
+              product={product}
+              selectOpt={selectOpt}
+              setOptValue={setOptValue}
+            />
+          );
+        })}
     </ListWrapper>
   );
 };

--- a/src/components/CardList/SelectOpt.jsx
+++ b/src/components/CardList/SelectOpt.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import styled from 'styled-components';
 
-const SelectOpt = ({ productStatus, setOptValue }) => {
-  const handleChange = e => {
-    setOptValue(e.target.value);
+const SelectOpt = ({ productId, status, setOptValue }) => {
+  const handleChange = (e, productId) => {
+    setOptValue(e.target.value, productId);
   };
 
   return (
-    <SelectOption onChange={handleChange} value={productStatus}>
+    <SelectOption onChange={e => handleChange(e, productId)} value={status}>
       {SELECT_OPT_LIST.map(opt => {
         const { id, value, title } = opt;
         return (

--- a/src/pages/ProductSell/ProductSell.jsx
+++ b/src/pages/ProductSell/ProductSell.jsx
@@ -1,7 +1,237 @@
-import React from 'react';
+import React, { useState, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+import SellSubmit from './component/SellSubmit';
+import { DESC_TXT, INPUT_DATA } from './SellData';
+// import { fetchApi, API } from '../../config';
 
 const ProductSell = () => {
-  return <div>ProductSell</div>;
+  const [photo, setPhoto] = useState([]);
+  const [imgList, setImgList] = useState([]);
+  const [sellList, setSellList] = useState({
+    title: '',
+    subCategoryId: 0,
+    region: '',
+    conditionId: '1',
+    exchangeable: '1',
+    price: 0,
+    description: '',
+    userId: 1,
+  });
+
+  const navigate = useNavigate();
+  const imgPreview = useRef();
+  const uploadId = useRef(0);
+
+  const handleSellList = e => {
+    const { name, value } = e.target;
+    setSellList(prev => ({ ...prev, [name]: value }));
+  };
+
+  const uploadPhoto = e => {
+    setPhoto(prev => [
+      ...prev,
+      {
+        id: uploadId.current++,
+        value: URL.createObjectURL(imgPreview.current.files[0]),
+      },
+    ]);
+    setImgList(prev => [...prev, e.target.files[0]]);
+  };
+
+  const removePhoto = (e, targetId) => {
+    e.preventDefault();
+    const filteredPhoto = photo.filter(({ id }) => targetId !== id);
+    const filteredImgList = imgList.filter((_, i) => targetId !== i);
+
+    setPhoto(filteredPhoto);
+    setImgList(filteredImgList);
+  };
+
+  const submit = e => {
+    e.preventDefault();
+    fetch('http://10.58.52.223:3000/products', {
+      method: 'POST',
+      body: new URLSearchParams({ images: imgList, ...sellList }),
+    })
+      .then(res => res.json())
+      .then(result => {
+        if (result.message === '판매상품_등록완료') {
+          alert('상품이 등록되었습니다!');
+          navigate('/productdetail');
+        } else if (result.message) {
+          alert(result.message);
+        }
+      })
+      .catch(error => console.error(error));
+    // fetchData();
+  };
+
+  // const fetchData = async () => {
+  //   const data = await fetchApi(
+  //     `${API.products}`,
+  //     'POST',
+  //     new URLSearchParams({ images: imgList, ...sellList }),
+  //     false
+  //   );
+  //   if (data.message === '판매상품_등록완료') {
+  //     alert('상품이 등록되었습니다!');
+  //     navigate('/productdetail');
+  //   } else if (data.message) {
+  //     alert(data.message);
+  //   }
+  // };
+
+  return (
+    <Container>
+      <Title>기본정보</Title>
+      <Line />
+      <SubTitle>상품이미지 *</SubTitle>
+      <ImgUl>
+        <ImgLi>
+          <ImgLabel htmlFor="imgupload">
+            <Add>+</Add>
+          </ImgLabel>
+          <ImgInput
+            type="file"
+            id="imgupload"
+            multiple
+            ref={imgPreview}
+            onChange={uploadPhoto}
+            accept="image/*"
+            name="images"
+          />
+        </ImgLi>
+        {photo.map(({ id, value }, idx) => {
+          return (
+            <ImgLi key={idx}>
+              <ImgPost src={value} alt="" />
+              <DeleteButton onClick={e => removePhoto(e, id)}>x</DeleteButton>
+            </ImgLi>
+          );
+        })}
+      </ImgUl>
+      <DescDiv>
+        {DESC_TXT.map(props => {
+          return <DescText key={props.id}>{props.text}</DescText>;
+        })}
+      </DescDiv>
+      {INPUT_DATA.map(list => {
+        return (
+          <SellSubmit
+            list={list}
+            key={list.id}
+            handleSellList={handleSellList}
+            sellList={sellList}
+          />
+        );
+      })}
+      <ButtonDiv>
+        <PostButton onClick={submit}>등록하기</PostButton>
+      </ButtonDiv>
+    </Container>
+  );
 };
 
 export default ProductSell;
+
+const Container = styled.form`
+  width: 800px;
+  margin: 70px auto;
+`;
+
+const Title = styled.p`
+  font-size: 26px;
+  font-weight: 700;
+  color: ${props => props.theme.darkGrey};
+`;
+
+const Line = styled.hr`
+  width: 100%;
+  margin-top: 30px;
+`;
+
+const SubTitle = styled.p`
+  font-size: 20px;
+  font-weight: 700;
+  margin: 50px 0 15px;
+  color: ${props => props.theme.darkGrey};
+`;
+
+const ButtonDiv = styled.div`
+  display: flex;
+  justify-content: end;
+`;
+
+const PostButton = styled.button`
+  background-color: ${props => props.theme.beige};
+  border: 0;
+  border-radius: 5px;
+  padding: 10px 35px;
+  color: white;
+  margin-top: 100px;
+  font-size: 18px;
+  font-weight: 600;
+`;
+
+const ImgUl = styled.ul`
+  display: flex;
+  flex-wrap: wrap;
+  overflow-x: hidden;
+  margin-bottom: 20px;
+`;
+
+const ImgLi = styled.li`
+  margin: 0 20px 0 0;
+  position: relative;
+`;
+
+const ImgLabel = styled.label`
+  width: 230px;
+  height: 230px;
+  border: 1px solid #e6e5ef;
+  border-radius: 5px;
+  background-color: #fafafd;
+  color: #e6e5ef;
+  margin-bottom: 20px;
+  cursor: pointer;
+  display: block;
+`;
+
+const Add = styled.div`
+  font-size: 40px;
+  padding-left: 45%;
+  padding-top: 40%;
+`;
+
+const ImgInput = styled.input`
+  display: none;
+`;
+
+const ImgPost = styled.img`
+  width: 230px;
+  height: 230px;
+  border-radius: 5px;
+  object-fit: cover;
+`;
+
+const DeleteButton = styled.button`
+  color: white;
+  position: absolute;
+  top: 8px;
+  right: 10px;
+  font-size: 20px;
+  border: none;
+  background: none;
+  cursor: pointer;
+`;
+
+const DescDiv = styled.div`
+  margin-top: 5px;
+`;
+
+const DescText = styled.p`
+  color: #4aa4ff;
+  margin: 5px 0;
+  font-weight: ${props => (props.id === 1 ? 600 : '')}; // 질문 1
+`;

--- a/src/pages/ProductSell/SellData.jsx
+++ b/src/pages/ProductSell/SellData.jsx
@@ -1,0 +1,65 @@
+export const DESC_TXT = [
+  { id: 0, text: '* 상품 이미지는 640x640에 최적화 되어 있습니다.' },
+  {
+    id: 1,
+    text: '- 상품 이미지는 PC에서는 1:1, 모바일에서는 1:1.23 비율로 보여집니다.',
+  },
+  { id: 2, text: '- 이미지는 상품 등록 시 정사각형으로 잘려서 등록됩니다.' },
+  { id: 3, text: '- 이미지를 클릭할 경우 원본 이미지를 확인할 수 있습니다.' },
+  { id: 4, text: '- 이미지를 클릭 후 이동하여 등록순서를 변경할 수 있습니다.' },
+  {
+    id: 5,
+    text: '- 큰 이미지일 경우 이미지가 깨지는 경우가 발생할 수 있습니다.',
+  },
+  {
+    id: 6,
+    text: '- 최대 지원 사이즈인 640 X 640으로 리사이즈 해서 올려주세요.(개당 이미지 최대 10M)',
+  },
+];
+
+export const INPUT_DATA = [
+  {
+    id: 1,
+    title: '제목',
+    type: 'text',
+    name: 'title',
+    placeholder: '상품 제목을 입력해주세요',
+  },
+  { id: 2, title: '카테고리', type: 'select' },
+  {
+    id: 3,
+    title: '거래지역',
+    type: 'text',
+    placeholder: '거래 지역을 입력해주세요',
+    name: 'region',
+  },
+  {
+    id: 4,
+    title: '상태',
+    type: 'radio',
+    name: 'conditionId',
+    value: '1',
+  },
+  {
+    id: 5,
+    title: '교환',
+    type: 'radio',
+    name: 'exchangeable',
+    value: '1',
+  },
+  {
+    id: 6,
+    title: '가격',
+    type: 'number',
+    name: 'price',
+    placeholder: '숫자만 입력해 주세요',
+    width: '250px',
+  },
+  {
+    id: 7,
+    title: '상품설명',
+    name: 'description',
+    placeholder: '숫자만 입력해 주세요',
+    width: '250px',
+  },
+];

--- a/src/pages/ProductSell/component/Category.jsx
+++ b/src/pages/ProductSell/component/Category.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Category = ({ sellList, handleSellList }) => {
+  return (
+    <>
+      <SelectOpt
+        name="subCategoryId"
+        value={sellList.subCategoryId}
+        onChange={handleSellList}
+      >
+        {CATEGORY_LIST.map(({ id, title }) => {
+          return (
+            <Opt key={id} value={id}>
+              {title}
+            </Opt>
+          );
+        })}
+      </SelectOpt>
+      <SelectResult>
+        선택한 카테고리 : {CATEGORY_TITLE[sellList.subCategoryId]}
+      </SelectResult>
+    </>
+  );
+};
+export default Category;
+
+const SelectOpt = styled.select`
+  width: 50%;
+  height: 40px;
+  border-radius: 5px;
+  border: 1px solid ${props => props.theme.whiteGreyD9};
+`;
+
+const Opt = styled.option`
+  padding-left: 10px;
+  color: ${props => props.theme.whiteGreyD9};
+`;
+
+const SelectResult = styled.p`
+  font-size: 15px;
+  margin-top: 20px;
+  color: ${props => props.theme.darkbeige};
+`;
+
+export const CATEGORY_LIST = [
+  { id: 0, value: 'subCategoryId', title: '카테고리를 선택해주세요' },
+  { id: 1, value: 'inner', title: '내의/속옷' },
+  { id: 2, value: 'topbottom', title: '상의/하의' },
+  { id: 3, value: 'onpiece', title: '원피스' },
+  { id: 4, value: 'shoes', title: '신발' },
+  { id: 5, value: 'accessory', title: '악세사리' },
+  { id: 6, value: 'bedding', title: '이불/침구' },
+  { id: 7, value: 'toy', title: '인형/모빌' },
+];
+
+const CATEGORY_TITLE = {
+  0: '',
+  1: '내의/속옷',
+  2: '상의/하의',
+  3: '원피스',
+  4: '신발',
+  5: '악세사리',
+  6: '이불/침구',
+  7: '인형/모빌',
+};

--- a/src/pages/ProductSell/component/Description.jsx
+++ b/src/pages/ProductSell/component/Description.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Description = ({ sellList, handleSellList }) => {
+  return (
+    <DetailDiv>
+      <DetailTextarea
+        type="text"
+        name="description"
+        onChange={handleSellList}
+        value={sellList.description}
+        placeholder="여러 장의 상품 사진과 구입 연도, 브랜드, 사용감, 하자 유무 등
+        구매자에게 필요한 정보를 꼭 포함해 주세요. (10자 이상)&#13;&#10;안전하고 건전한 거래 환경을 위해 과학기술정보통신부,
+        한국인터넷진흥원과 BaBee(주)가 함께 합니다."
+      />
+      <DetailCount>{sellList.description.length}/2000</DetailCount>
+    </DetailDiv>
+  );
+};
+
+export default Description;
+
+const DetailDiv = styled.div`
+  position: relative;
+`;
+
+const DetailTextarea = styled.textarea`
+  resize: none;
+  width: 100%;
+  height: 350px;
+  border-radius: 5px;
+  border: 1px solid ${props => props.theme.whiteGreyD9};
+  padding: 15px 0 0 15px;
+  &::placeholder {
+    color: ${props => props.theme.whiteGreyD9};
+  }
+`;
+
+const DetailCount = styled.span`
+  position: absolute;
+  bottom: 15px;
+  right: 20px;
+  color: ${props => props.theme.darkGrey};
+`;

--- a/src/pages/ProductSell/component/SellSubmit.jsx
+++ b/src/pages/ProductSell/component/SellSubmit.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import styled from 'styled-components';
+import Description from './Description';
+import Category from './Category';
+import TypeButton from './TypeButton';
+
+const SellSubmit = ({
+  list: { title, type, placeholder, width, name, value },
+  handleSellList,
+  sellList,
+}) => {
+  return (
+    <div>
+      <Title>{title}</Title>
+      {(type === 'text' || type === 'number') && (
+        <TitleDiv>
+          <InputStyle
+            placeholder={placeholder}
+            width={width}
+            name={name}
+            onChange={handleSellList}
+          />
+          {title === '제목' && (
+            <TitleCount>{sellList.title.length} / 40</TitleCount>
+          )}
+          {title === '가격' && <span>원</span>}
+          {title === '수량' && <span>개</span>}
+        </TitleDiv>
+      )}
+      {type === 'select' && (
+        <Category handleSellList={handleSellList} sellList={sellList} />
+      )}
+      {type === 'radio' && (
+        <TypeButton
+          handleSellList={handleSellList}
+          sellList={sellList}
+          name={name}
+          value={value}
+        />
+      )}
+      {title === '상품설명' && (
+        <Description handleSellList={handleSellList} sellList={sellList} />
+      )}
+    </div>
+  );
+};
+
+export default SellSubmit;
+
+const Title = styled.p`
+  font-size: 20px;
+  font-weight: 700;
+  margin: 50px 0 15px;
+  color: ${props => props.theme.darkGrey};
+`;
+
+const InputStyle = styled.input`
+  width: ${props => props.width || '100%'};
+  height: 40px;
+  border-radius: 5px;
+  padding-left: 10px;
+  border: 1px solid ${props => props.theme.whiteGreyD9};
+  &::placeholder {
+    color: ${props => props.theme.whiteGreyD9};
+  }
+  margin-right: 10px;
+`;
+
+const TitleDiv = styled.div`
+  position: relative;
+`;
+
+const TitleCount = styled.span`
+  position: absolute;
+  top: 12px;
+  right: 20px;
+  color: ${props => props.theme.darkGrey};
+`;

--- a/src/pages/ProductSell/component/TypeButton.jsx
+++ b/src/pages/ProductSell/component/TypeButton.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const TypeButton = ({ sellList, handleSellList, name, value }) => {
+  return (
+    <StatusWrapper>
+      <StatusDiv>
+        <StatusInput
+          type="radio"
+          name={name}
+          value={1}
+          checked={sellList[name] === value}
+          onChange={handleSellList}
+        />
+        <Statuslabel>
+          {name === 'conditionId' ? '중고상품' : '교환 가능'}
+        </Statuslabel>
+      </StatusDiv>
+      <StatusDiv>
+        <StatusInput
+          type="radio"
+          name={name}
+          value={name === 'conditionId' ? 2 : 0}
+          checked={sellList[name] !== value}
+          onChange={handleSellList}
+        />
+        <Statuslabel>
+          {name === 'conditionId' ? '새상품' : '교환 불가'}
+        </Statuslabel>
+      </StatusDiv>
+    </StatusWrapper>
+  );
+};
+
+export default TypeButton;
+
+const StatusWrapper = styled.div`
+  display: flex;
+  height: auto;
+  width: 100%;
+`;
+
+const StatusDiv = styled.div`
+  display: flex;
+  align-items: center;
+  position: relative;
+  margin-right: 25px;
+`;
+
+const Statuslabel = styled.label``;
+
+const StatusInput = styled.input.attrs({ type: 'radio' })`
+  vertical-align: middle;
+  appearance: none;
+  border: 1px solid gray;
+  border-radius: 50%;
+  width: 1em;
+  height: 1em;
+  margin-right: 10px;
+  &:checked {
+    border: 0.3em solid #b8a990;
+  }
+`;

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -1,7 +1,7 @@
 const theme = {
   beigeGrey: '#A19E9A', // 로고 컬러
   beige: '#D0C0A5', // 로고 컬러
-  darkbeige: 'B8A990', // 텍스트용 베이지
+  darkbeige: '#B8A990', // 텍스트용 베이지
   whiteGreyD9: '#D9D9D9', // nav바 선, button 선
   whiteGreyF6: '#F6F6F6', // 배경색
   darkGrey: '#333333', // 검정대신 쓸 것


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
- 판매하기 페이지 레이아웃 및 기능 구현
- 7개의 상태 데이터 한곳에서 관리
- 서버에 이미지 및 제품 정보 전달 후 제품 등록


<br />

## :: 구현 사항 설명
1. 7개의 상태 데이터 한곳에서 관리
- 이벤트 핸들러와 스테이트를 최상단인 productsell 페이지에서 관리

2. 코드의 간소화
- 상수데이터의 사용
- 동일한 구조의 input태그 레이아웃 재활용

3. Input 태그의 입력값에 따른 글자수 계산
- props로 전달받은 state값에 length메서스 사용

4. Formdata 사용으로 제품등록 정보전달
(추가예정)

5. formdata 사용으로 이미지 정보전달
(추가예정)


<br />

## :: 성장 포인트
- 처음 사용해보는 데이터 구조로 백엔드와의 많은 소통시도
- formdata 사용으로 이미지 업로드에 대한 이해를 하는중
- 컴포넌트 재사용시 각각 커스텀하기 어렵지만 조건문을 적절히 잘 사용하는 법을 깨우침

<br />

## :: 기타 질문 및 특이 사항
